### PR TITLE
Be able to add children to scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,7 +378,7 @@ To remove complexity, the `ResizeObserver` API by default if it is available in 
 
 ## 3.0.0
 
-- feat(SmoothScroll): Add `[smoothScroll]` directive which can be imported independently e.g. `import {SmoothScrollModule} from 'ngx-scrollbar'`.
+- feat(SmoothScroll): Add `[smoothScroll]` directive which can be imported independently e.g. `import {SmoothScrollModule} from '@metrica-sports/ngx-scrollbar'`.
 - feat(NgScrollbar): Add `[disableOnBreakpoints]` to disable the custom scrollbars on certain breakpoints.
 - refactor(NgScrollbar): Improve performance by removing `(scrollState)` output which causes a change detection on each emit.
 - fix(NgScrollbar): Fallback to native scrollbars on mobile, closes [#59](https://github.com/MurhafSousli/ngx-scrollbar/issues/59).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "serve:ssr": "node dist/ngx-scrollbar-demo/server/main.js",
     "build:ssr": "npm run build-demo && ng run ngx-scrollbar-demo:server"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MurhafSousli/ngx-scrollbar"

--- a/projects/ngx-scrollbar-demo/src/app/app.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, AfterViewInit, ViewChild } from '@angular/core';
 import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
-import { NgScrollbar } from 'ngx-scrollbar';
+import { NgScrollbar } from '@metrica-sports/ngx-scrollbar';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { auditTime, map, tap } from 'rxjs/operators';
 

--- a/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
-import { NgScrollbar } from 'ngx-scrollbar';
+import { NgScrollbar } from '@metrica-sports/ngx-scrollbar';
 
 @Component({
   selector: 'app-example-scrollto-element',

--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.html
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.html
@@ -77,6 +77,15 @@
                 <app-logo></app-logo>
               </div>
 
+              <div scrollbar-x-content class="scrollbar-x-container">
+                <span class="scrollbar-handle"></span>
+                <span class="scrollbar-handle"></span>
+              </div>
+              <div scrollbar-y-content class="scrollbar-y-container">
+                <span class="scrollbar-handle"></span>
+                <span class="scrollbar-handle"></span>
+              </div>
+
             </ng-scrollbar>
           </ng-template>
         </div>

--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.scss
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.scss
@@ -111,6 +111,32 @@ $scrollable-height: 296px;
     margin-right: 1em;
     display: inline-block;
   }
+
+  .scrollbar-x-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 100%;
+    padding: 0px 3px;
+  }
+
+  .scrollbar-y-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    height: 100%;
+    padding: 3px 0px;
+  }
+
+  .scrollbar-handle {
+    width: 6px;
+    height: 6px;
+    background: blue;
+    border-radius: 50%;
+    cursor: pointer;
+    pointer-events: all;
+  }
 }
 
 .mat-mdc-card {

--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.ts
@@ -9,7 +9,7 @@ import {
   ScrollbarTrack,
   ScrollbarPosition,
   ScrollbarVisibility
-} from 'ngx-scrollbar';
+} from '@metrica-sports/ngx-scrollbar';
 import { ResizeChange } from './resize-form/resize-form.component';
 import { ToggleChange } from './toggle-form/toggle-form.component';
 import { ReachedEvent } from './reached-notifier/reached-notifier.component';

--- a/projects/ngx-scrollbar-demo/src/app/example2/example2.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/example2/example2.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
-import { NgScrollbar } from 'ngx-scrollbar';
+import { NgScrollbar } from '@metrica-sports/ngx-scrollbar';
 // import { NgScrollbar } from '../../../../ngx-scrollbar/src/public-api';
 
 @Component({

--- a/projects/ngx-scrollbar-demo/src/app/shared/navigation-toolbar/navigation-toolbar.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/shared/navigation-toolbar/navigation-toolbar.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ViewChild, AfterViewChecked, OnDestroy, NgZone, ChangeDetectionStrategy } from '@angular/core';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, tap } from 'rxjs/operators';
-import { NgScrollbar } from 'ngx-scrollbar';
+import { NgScrollbar } from '@metrica-sports/ngx-scrollbar';
 
 @Component({
   selector: 'app-navigation-toolbar',

--- a/projects/ngx-scrollbar-demo/src/app/shared/shared.module.ts
+++ b/projects/ngx-scrollbar-demo/src/app/shared/shared.module.ts
@@ -16,8 +16,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { ColorPickerModule } from 'ngx-color-picker';
-import { NgScrollbarModule } from 'ngx-scrollbar';
-import { NgScrollbarReachedModule } from 'ngx-scrollbar/reached-event';
+import { NgScrollbarModule } from '@metrica-sports/ngx-scrollbar';
+import { NgScrollbarReachedModule } from '@metrica-sports/ngx-scrollbar/reached-event';
 
 import { HeaderComponent } from './header/header.component';
 import { FooterComponent } from './footer/footer.component';

--- a/projects/ngx-scrollbar/package.json
+++ b/projects/ngx-scrollbar/package.json
@@ -1,18 +1,24 @@
 {
-  "name": "ngx-scrollbar",
-  "version": "11.0.0",
+  "name": "@metrica-sports/ngx-scrollbar",
+  "version": "1.0.0",
   "license": "MIT",
   "homepage": "https://ngx-scrollbar.netlify.com/",
+  "main": "ngx-scrollbar",
   "author": {
+    "name": "Metrica Sports",
+    "email": "info@metrica-sports.com"
+  },
+  "versionForked": "11.0.0",
+  "authorForked": {
     "name": "Murhaf Sousli",
-    "url": "http://github.com/murhafsousli"
+    "email": "murhafsousli@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MurhafSousli/ngx-scrollbar"
-  },
-  "bugs": {
-    "url": "http://github.com/murhafsousli/ngx-scrollbar/issues"
+    "url": "https://github.com/metrica-sports/ngx-scrollbar"
   },
   "keywords": [
     "scrollbar",

--- a/projects/ngx-scrollbar/reached-event/src/ng-scrollbar-reached.module.ts
+++ b/projects/ngx-scrollbar/reached-event/src/ng-scrollbar-reached.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BidiModule } from '@angular/cdk/bidi';
-import { NgScrollbarModule } from 'ngx-scrollbar';
+import { NgScrollbarModule } from '@metrica-sports/ngx-scrollbar';
 import {
   NgScrollbarReachedTop,
   NgScrollbarReachedBottom,

--- a/projects/ngx-scrollbar/reached-event/src/ng-scrollbar-reached.ts
+++ b/projects/ngx-scrollbar/reached-event/src/ng-scrollbar-reached.ts
@@ -1,7 +1,7 @@
 import { Directive, Optional, Input, Output, OnInit, OnDestroy, NgZone } from '@angular/core';
 import { Directionality } from '@angular/cdk/bidi';
 import { RtlScrollAxisType } from '@angular/cdk/platform';
-import { NgScrollbar } from 'ngx-scrollbar';
+import { NgScrollbar } from '@metrica-sports/ngx-scrollbar';
 import { Observable, Subject, Subscription, Subscriber } from 'rxjs';
 import { filter, map, tap, distinctUntilChanged } from 'rxjs/operators';
 

--- a/projects/ngx-scrollbar/src/lib/hide-native-scrollbar/hide-native-scrollbar.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/hide-native-scrollbar/hide-native-scrollbar.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { NgScrollbarModule, NgScrollbar } from 'ngx-scrollbar';
+import { NgScrollbarModule, NgScrollbar } from '@metrica-sports/ngx-scrollbar';
 
 import { HideNativeScrollbar } from './hide-native-scrollbar';
 

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar-base.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar-base.ts
@@ -1,5 +1,5 @@
 import { Directive } from '@angular/core';
-import { SmoothScrollToOptions } from 'ngx-scrollbar/smooth-scroll';
+import { SmoothScrollToOptions } from '@metrica-sports/ngx-scrollbar/smooth-scroll';
 import { Observable } from 'rxjs';
 import { ScrollViewport } from './scroll-viewport';
 import { ScrollbarManager } from './utils/scrollbar-manager';

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.html
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.html
@@ -15,12 +15,15 @@
                  *ngIf="state.horizontalUsed"
                  [attr.scrollable]="state.isHorizontallyScrollable"
                  [attr.fit]="state.verticalUsed">
+      <ng-content select="[scrollbar-x-content]" ngProjectAs="[scrollbar-x-project]">
+      </ng-content>
     </scrollbar-x>
     <scrollbar-y #scrollbarY
                  *ngIf="state.verticalUsed"
                  [attr.scrollable]="state.isVerticallyScrollable"
                  [attr.fit]="state.horizontalUsed">
+      <ng-content select="[scrollbar-y-content]" ngProjectAs="[scrollbar-y-project]">
+      </ng-content>
     </scrollbar-y>
   </ng-container>
 </div>
-

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.module.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { BidiModule } from '@angular/cdk/bidi';
 import { PortalModule } from '@angular/cdk/portal';
 import { PlatformModule } from '@angular/cdk/platform';
-import { SmoothScrollModule } from 'ngx-scrollbar/smooth-scroll';
+import { SmoothScrollModule } from '@metrica-sports/ngx-scrollbar/smooth-scroll';
 
 import { NgScrollbar } from './ng-scrollbar';
 import { HideNativeScrollbar } from './hide-native-scrollbar/hide-native-scrollbar';

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.ts
@@ -20,7 +20,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { fromEvent, Observable, Subject } from 'rxjs';
 import { auditTime, filter, map, pairwise, pluck, takeUntil, tap } from 'rxjs/operators';
 import { ScrollViewport } from './scroll-viewport';
-import { SmoothScrollElement, SmoothScrollManager, SmoothScrollToOptions, SmoothScrollToElementOptions } from 'ngx-scrollbar/smooth-scroll';
+import { SmoothScrollElement, SmoothScrollManager, SmoothScrollToOptions, SmoothScrollToElementOptions } from '@metrica-sports/ngx-scrollbar/smooth-scroll';
 import { ScrollbarManager } from './utils/scrollbar-manager';
 import {
   ScrollbarAppearance,

--- a/projects/ngx-scrollbar/src/lib/scrollbar/scrollbar.component.ts
+++ b/projects/ngx-scrollbar/src/lib/scrollbar/scrollbar.component.ts
@@ -13,7 +13,9 @@ import { Scrollbar } from './scrollbar';
   styleUrls: ['./vertical.scss'],
   template: `
     <div scrollbarTrackY class="ng-scrollbar-track {{cmp.trackClass}}">
-      <div scrollbarThumbY class="ng-scrollbar-thumb {{cmp.thumbClass}}"></div>
+      <div scrollbarThumbY class="ng-scrollbar-thumb {{cmp.thumbClass}}">
+        <ng-content select="[scrollbar-y-project]"></ng-content>
+      </div>
     </div>
   `
 })
@@ -46,7 +48,9 @@ export class ScrollbarY extends Scrollbar {
   styleUrls: ['./horizontal.scss'],
   template: `
     <div scrollbarTrackX class="ng-scrollbar-track {{cmp.trackClass}}">
-      <div scrollbarThumbX class="ng-scrollbar-thumb {{cmp.thumbClass}}"></div>
+      <div scrollbarThumbX class="ng-scrollbar-thumb {{cmp.thumbClass}}">
+        <ng-content select="[scrollbar-x-project]"></ng-content>
+      </div>
     </div>
   `
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,13 +20,13 @@
       "dom"
     ],
     "paths": {
-      "ngx-scrollbar": [
+      "@metrica-sports/ngx-scrollbar": [
         "projects/ngx-scrollbar/src/public-api"
       ],
-      "ngx-scrollbar/smooth-scroll": [
+      "@metrica-sports/ngx-scrollbar/smooth-scroll": [
         "projects/ngx-scrollbar/smooth-scroll/src/public_api"
       ],
-      "ngx-scrollbar/reached-event": [
+      "@metrica-sports/ngx-scrollbar/reached-event": [
         "projects/ngx-scrollbar/reached-event/src/public_api"
       ]
     },


### PR DESCRIPTION
In this way, we could add children for handles in the edges and have, for instance, zoom/resize logic related to it.

![image](https://user-images.githubusercontent.com/32394038/236754981-4a6e2919-8433-4a67-9764-e97c586e572c.png)
