### PR TITLE
Allow having mouse event listeners to children elements

### DIFF
--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.html
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.html
@@ -50,6 +50,39 @@
               <app-logo></app-logo>
             </div>
 
+            <div
+              scrollbar-x-content
+              class="scrollbar-x-container"
+              (mousedown)="onMouseDown($event, 'horizontal')"
+            >
+              <span
+                class="scrollbar-handle"
+                (mousedown)="onMouseDown($event, 'horizontal-left')"
+              >
+              </span>
+              <span
+                class="scrollbar-handle"
+                (mousedown)="onMouseDown($event, 'horizontal-right')"
+              >
+              </span>
+            </div>
+            <div
+              scrollbar-y-content
+              class="scrollbar-y-container"
+              (mousedown)="onMouseDown($event, 'vertical')"
+            >
+              <span
+                class="scrollbar-handle"
+                (mousedown)="onMouseDown($event, 'vertical-top')"
+              >
+              </span>
+              <span
+                class="scrollbar-handle"
+                (mousedown)="onMouseDown($event, 'vertical-bottom')"
+              >
+              </span>
+            </div>
+
           </ng-scrollbar>
 
           <ng-template #viewportPointerEvents>
@@ -76,16 +109,7 @@
               <div *ngIf="scrollToElementSelected" id="target">
                 <app-logo></app-logo>
               </div>
-
-              <div scrollbar-x-content class="scrollbar-x-container">
-                <span class="scrollbar-handle"></span>
-                <span class="scrollbar-handle"></span>
-              </div>
-              <div scrollbar-y-content class="scrollbar-y-container">
-                <span class="scrollbar-handle"></span>
-                <span class="scrollbar-handle"></span>
-              </div>
-
+              
             </ng-scrollbar>
           </ng-template>
         </div>

--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.ts
@@ -96,6 +96,36 @@ export class ExampleXComponent {
     }
   }
 
+  onMouseDown(event, id) {
+    // We cannot use stop-propagation because scrollbar logic would be blocked.
+    if (event.target !== event.currentTarget) {
+      return
+    }
+
+    console.log('onMouseDown', id);
+
+    const mouseMoveEventListener = this.onMouseMove(id)
+    document.addEventListener('mousemove', mouseMoveEventListener)
+    document.addEventListener('mouseup', this.onMouseUp(id, mouseMoveEventListener))
+  }
+
+  onMouseMove(id) {
+    const eventListener = (event) => {
+      console.log('onMouseMove', id);
+    }
+
+    return eventListener
+  }
+
+  onMouseUp(id, mouseMoveEventListener) {
+    const eventListener = (event) => {
+      console.log('onMouseUp', id);
+      document.removeEventListener('mousemove', mouseMoveEventListener)
+      document.removeEventListener('mouseup', eventListener)
+    }
+
+    return eventListener
+  }
 }
 
 const content = `

--- a/projects/ngx-scrollbar/package.json
+++ b/projects/ngx-scrollbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrica-sports/ngx-scrollbar",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "homepage": "https://ngx-scrollbar.netlify.com/",
   "main": "ngx-scrollbar",

--- a/projects/ngx-scrollbar/src/lib/scrollbar/thumb/thumb.ts
+++ b/projects/ngx-scrollbar/src/lib/scrollbar/thumb/thumb.ts
@@ -75,9 +75,9 @@ export abstract class ThumbAdapter {
       }),
     );
 
-    const dragging = fromEvent<MouseEvent>(this.document, 'mousemove', { capture: true, passive: true }).pipe(stopPropagation());
+    const dragging = fromEvent<MouseEvent>(this.document, 'mousemove', { passive: true }).pipe(stopPropagation());
 
-    const dragEnd = fromEvent<MouseEvent>(this.document, 'mouseup', { capture: true }).pipe(
+    const dragEnd = fromEvent<MouseEvent>(this.document, 'mouseup', { passive: true }).pipe(
       stopPropagation(),
       enableSelection(this.document),
       tap(() => this.setDragging(false))


### PR DESCRIPTION
`ThumbAdapter` class was blocking mouse-up events and we weren't able to handle properly these ones in custom children. With this change, now we'll be able to perform custom actions related to mouse events in any child added into scrollbar.

The way of proceed will be subscribing to `mousedown` event in the HTML element. Then, in the callback, will add `mousemove` and/or `mouseup` event listeners to the `document`. Don't forget to release these events when `mouseup` event in invoked.

![image](https://github.com/metrica-sports/ngx-scrollbar/assets/32394038/cb3b652f-8113-4910-a4ac-7e375a6e8caa)
