### PR TITLE
Allow displaying scrollbar thumbs always

### DIFF
--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.html
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.html
@@ -209,6 +209,7 @@
             <mat-button-toggle value="native">Native</mat-button-toggle>
             <mat-button-toggle value="always">Always</mat-button-toggle>
             <mat-button-toggle value="hover">Hover</mat-button-toggle>
+            <mat-button-toggle value="always-thumb">Always Thumb</mat-button-toggle>
           </mat-button-toggle-group>
         </mat-expansion-panel>
 

--- a/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/example-x/example-x.component.ts
@@ -45,7 +45,7 @@ export class ExampleXComponent {
   cssVariables: SafeStyle;
   position: ScrollbarPosition = 'native';
   direction: ScrollbarTrack = 'all';
-  visibility: ScrollbarVisibility = 'native';
+  visibility: ScrollbarVisibility = 'always-thumb';
   appearance: ScrollbarAppearance = 'compact';
 
   reached = new BehaviorSubject<ReachedEvent>({});

--- a/projects/ngx-scrollbar/package.json
+++ b/projects/ngx-scrollbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrica-sports/ngx-scrollbar",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "homepage": "https://ngx-scrollbar.netlify.com/",
   "main": "ngx-scrollbar",

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar-base.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar-base.ts
@@ -3,13 +3,14 @@ import { SmoothScrollToOptions } from '@metrica-sports/ngx-scrollbar/smooth-scro
 import { Observable } from 'rxjs';
 import { ScrollViewport } from './scroll-viewport';
 import { ScrollbarManager } from './utils/scrollbar-manager';
-import { ScrollbarPointerEventsMethod } from './ng-scrollbar.model';
+import { NgScrollbarState, ScrollbarPointerEventsMethod } from './ng-scrollbar.model';
 
 @Directive()
 export abstract class NgScrollbarBase {
   abstract manager: ScrollbarManager;
 
   abstract viewport: ScrollViewport;
+  abstract state: NgScrollbarState;
   abstract trackClass: string;
   abstract thumbClass: string;
   abstract minThumbSize: number;

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.html
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.html
@@ -12,16 +12,16 @@
   </div>
   <ng-container *ngIf="!disabled">
     <scrollbar-x #scrollbarX
-                 *ngIf="state.horizontalUsed"
-                 [attr.scrollable]="state.isHorizontallyScrollable"
-                 [attr.fit]="state.verticalUsed">
+                 *ngIf="state.horizontalUsed || state.horizontalDisplayed"
+                 [attr.scrollable]="state.horizontalDisplayed"
+                 [attr.fit]="state.verticalUsed || state.verticalDisplayed">
       <ng-content select="[scrollbar-x-content]" ngProjectAs="[scrollbar-x-project]">
       </ng-content>
     </scrollbar-x>
     <scrollbar-y #scrollbarY
-                 *ngIf="state.verticalUsed"
-                 [attr.scrollable]="state.isVerticallyScrollable"
-                 [attr.fit]="state.horizontalUsed">
+                 *ngIf="state.verticalUsed || state.verticalDisplayed"
+                 [attr.scrollable]="state.verticalDisplayed"
+                 [attr.fit]="state.horizontalUsed || state.horizontalDisplayed">
       <ng-content select="[scrollbar-y-content]" ngProjectAs="[scrollbar-y-project]">
       </ng-content>
     </scrollbar-y>

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.model.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.model.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 export type ScrollbarAppearance = 'standard' | 'compact';
 export type ScrollbarTrack = 'vertical' | 'horizontal' | 'all';
-export type ScrollbarVisibility = 'hover' | 'always' | 'native';
+export type ScrollbarVisibility = 'hover' | 'always' | 'native' | 'always-thumb';
 export type ScrollbarPosition = 'native' | 'invertY' | 'invertX' | 'invertAll';
 export type ScrollbarPointerEventsMethod = 'viewport' | 'scrollbar';
 
@@ -95,6 +95,8 @@ export interface NgScrollbarState {
   horizontalUsed?: boolean;
   isVerticallyScrollable?: boolean;
   isHorizontallyScrollable?: boolean;
+  verticalDisplayed?: boolean;
+  horizontalDisplayed?: boolean;
   verticalHovered?: boolean;
   horizontalHovered?: boolean;
   verticalDragging?: boolean;

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.ts
@@ -210,16 +210,20 @@ export class NgScrollbar implements OnInit, OnChanges, AfterViewInit, OnDestroy 
     let horizontalUsed: boolean = false;
     let isVerticallyScrollable: boolean = false;
     let isHorizontallyScrollable: boolean = false;
+    let verticalDisplayed: boolean = false;
+    let horizontalDisplayed: boolean = false;
 
     // Check if vertical scrollbar should be displayed
     if (this.track === 'all' || this.track === 'vertical') {
       isVerticallyScrollable = this.viewport!.scrollHeight > this.viewport!.clientHeight;
       verticalUsed = this.visibility === 'always' || isVerticallyScrollable;
+      verticalDisplayed = isVerticallyScrollable || this.visibility === 'always-thumb';
     }
     // Check if horizontal scrollbar should be displayed
     if (this.track === 'all' || this.track === 'horizontal') {
       isHorizontallyScrollable = this.viewport!.scrollWidth > this.viewport!.clientWidth;
       horizontalUsed = this.visibility === 'always' || isHorizontallyScrollable;
+      horizontalDisplayed = isHorizontallyScrollable || this.visibility === 'always-thumb';
     }
 
     // Update inner wrapper attributes
@@ -234,7 +238,9 @@ export class NgScrollbar implements OnInit, OnChanges, AfterViewInit, OnDestroy 
       verticalUsed,
       horizontalUsed,
       isVerticallyScrollable,
-      isHorizontallyScrollable
+      isHorizontallyScrollable,
+      verticalDisplayed,
+      horizontalDisplayed
     });
   }
 

--- a/projects/ngx-scrollbar/src/lib/scrollbar/thumb/thumb.ts
+++ b/projects/ngx-scrollbar/src/lib/scrollbar/thumb/thumb.ts
@@ -52,8 +52,15 @@ export abstract class ThumbAdapter {
 
   // Calculate and update thumb position and size
   update() {
-    const size = calculateThumbSize(this.track!.size, this.viewportScrollSize, this.cmp.minThumbSize!);
-    const position = calculateThumbPosition(this.viewportScrollOffset, this.viewportScrollMax, this.trackMax);
+    let useFullSize = false;
+    if (this.pageProperty === 'pageX') {
+      useFullSize = !this.cmp.state.isHorizontallyScrollable && this.cmp.state.horizontalDisplayed
+    } else {
+      useFullSize = !this.cmp.state.isVerticallyScrollable && this.cmp.state.verticalDisplayed
+    }
+
+    const size = calculateThumbSize(this.track!.size, this.viewportScrollSize, this.cmp.minThumbSize!, useFullSize);
+    const position = calculateThumbPosition(this.viewportScrollOffset, this.viewportScrollMax, this.trackMax, useFullSize);
     animationFrameScheduler.schedule(() => this.updateStyles(this.handleDirection(position, this.trackMax), size));
   }
 
@@ -117,7 +124,11 @@ export abstract class ThumbAdapter {
 /**
  * Calculate scrollbar thumb size
  */
-function calculateThumbSize(trackSize: number, contentSize: number, minThumbSize: number): number {
+function calculateThumbSize(trackSize: number, contentSize: number, minThumbSize: number, useFullSize: boolean): number {
+  if (useFullSize) {
+    return trackSize;
+  }
+
   const scrollbarRatio = trackSize / contentSize;
   const thumbSize = scrollbarRatio * trackSize;
   return Math.max(~~thumbSize, minThumbSize);
@@ -126,6 +137,10 @@ function calculateThumbSize(trackSize: number, contentSize: number, minThumbSize
 /**
  * Calculate scrollbar thumb position
  */
-function calculateThumbPosition(scrollPosition: number, scrollMax: number, trackMax: number): number {
+function calculateThumbPosition(scrollPosition: number, scrollMax: number, trackMax: number, useFullSize: boolean): number {
+  if (useFullSize) {
+    return 0.0;
+  }
+
   return scrollPosition * trackMax / scrollMax;
 }


### PR DESCRIPTION
Allow displaying scrollbar thumbs always (`always-thumb` visibility), i.e. even when there's nothing to scroll. In `always` visibility only scrollbar track is displayed and thumb only appears if there's something to scroll.

![image](https://github.com/metrica-sports/ngx-scrollbar/assets/32394038/082c871e-cf55-443e-ac13-d8fa7290026f)
